### PR TITLE
Add XFS reflink patch

### DIFF
--- a/0001-Create-any-XFS-filesystems-with-reflink-support.patch
+++ b/0001-Create-any-XFS-filesystems-with-reflink-support.patch
@@ -1,0 +1,27 @@
+From 08f5001b216a81675aaca24fd5d6bbe557875c96 Mon Sep 17 00:00:00 2001
+From: Rusty Bird <rustybird@net-c.com>
+Date: Thu, 13 Feb 2020 18:15:31 +0000
+Subject: [PATCH] Create any XFS filesystems with reflink support
+
+This means that if the user selects XFS for the root filesystem,
+/var/lib/qubes will use 'file-reflink' as its storage driver.
+---
+ blivet/tasks/fsmkfs.py | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/blivet/tasks/fsmkfs.py b/blivet/tasks/fsmkfs.py
+index ad166aa0..9388af5f 100644
+--- a/blivet/tasks/fsmkfs.py
++++ b/blivet/tasks/fsmkfs.py
+@@ -295,7 +295,7 @@ class XFSMkfs(FSMkfs):
+ 
+     @property
+     def args(self):
+-        return ["-f"]
++        return ["-f", "-m", "reflink=1"]
+ 
+ 
+ class UnimplementedFSMkfs(task.UnimplementedTask, FSMkfsTask):
+-- 
+2.21.1
+

--- a/python-blivet.spec.in
+++ b/python-blivet.spec.in
@@ -32,6 +32,7 @@ Source0: http://github.com/storaged-project/blivet/archive/%{realname}-%{realver
 Source1: http://github.com/storaged-project/blivet/archive/%{realname}-%{realversion}-tests.tar.gz
 Patch0: 0001-initial-PowerNV-class-support.patch
 Patch1: 0001-Double-recommended-LVM-thin-pool-metadata-space.patch
+Patch2: 0001-Create-any-XFS-filesystems-with-reflink-support.patch
 
 # Versions of required components (done so we make sure the buildrequires
 # match the requires versions of things).


### PR DESCRIPTION
Append `-m reflink=1` to `mkfs.xfs` options. Tested with Qubes-4.1-20200131-x86_64.iso.